### PR TITLE
图片后台上传，丢失扩展名

### DIFF
--- a/UEditor.Core/Handlers/CrawlerHandler.cs
+++ b/UEditor.Core/Handlers/CrawlerHandler.cs
@@ -90,7 +90,17 @@ namespace UEditor.Core.Handlers
                     State = "Url is not an image";
                     return this;
                 }
-                ServerUrl = PathFormatter.Format(Path.GetFileName(this.SourceUrl), Config.GetString("catcherPathFormat"));
+
+                var sourceUrl = "";
+                if (this.SourceUrl.Contains("?"))
+                {
+                    sourceUrl = this.SourceUrl.Substring(0, this.SourceUrl.IndexOf("?", StringComparison.Ordinal));
+                }
+                else
+                    sourceUrl = this.SourceUrl;
+
+                ServerUrl = PathFormatter.Format(Path.GetFileName(sourceUrl), Config.GetString("catcherPathFormat"));
+                
                 var savePath = Path.Combine(Config.WebRootPath, ServerUrl);
 
                 if (!Directory.Exists(Path.GetDirectoryName(savePath)))


### PR DESCRIPTION
这段语句的图片后台上传后，会丢失文件扩展名。把 src 中的 ? 去掉就好用了

```
<section class="Powered-by-XIUMI V5" style="position: static; box-sizing: border-box;" powered-by="xiumi.us">
        <section class="" style="text-align: center; margin-top: 10px; margin-bottom: 10px; position: static; box-sizing: border-box;">
            <section class="" style="max-width: 100%; vertical-align: middle; display: inline-block; overflow: hidden !important; box-sizing: border-box;">
                <img src="http://img.xiumi.us/xmi/ua/1gB5y/i/fdbdabf46da51702c17a99595981aa21-sz_52812.jpg?x-oss-process=style/xm" style="vertical-align: middle; max-width: 100%; box-sizing: border-box;" data-ratio="0.6140625" data-w="640"/>
            </section>
        </section>
    </section>
```